### PR TITLE
feat: adds imageProcessor and extends apiService for image upload

### DIFF
--- a/src/hooks/useImageProcessor.jsx
+++ b/src/hooks/useImageProcessor.jsx
@@ -1,0 +1,66 @@
+import { useCallback } from 'react';
+
+const useImageProcessor = ({ targetWidth, targetHeight }) => {
+    const processImage = useCallback((file, cropData = null) => {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+                const img = new Image();
+                img.onload = () => {
+                    const canvas = document.createElement('canvas');
+                    canvas.width = targetWidth;
+                    canvas.height = targetHeight;
+                    const ctx = canvas.getContext('2d');
+
+                    if (!ctx) return reject('Canvas context fehlt');
+
+                    if (cropData) {
+                        ctx.drawImage(
+                            img,
+                            cropData.x,
+                            cropData.y,
+                            cropData.width,
+                            cropData.height,
+                            0,
+                            0,
+                            targetWidth,
+                            targetHeight
+                        );
+                    } else {
+                        const side = Math.min(img.width, img.height);
+                        const sx = (img.width - side) / 2;
+                        const sy = (img.height - side) / 2;
+                        ctx.drawImage(
+                            img,
+                            sx,
+                            sy,
+                            side,
+                            side,
+                            0,
+                            0,
+                            targetWidth,
+                            targetHeight
+                        );
+                    }
+
+                    canvas.toBlob((blob) => {
+                        if (!blob) return reject('Fehler beim Erstellen des Bildes');
+
+                        const file = new File([blob], 'image.jpg', { type: 'image/jpeg' });
+                        resolve(file);
+                    }, 'image/jpeg');
+                };
+
+                img.onerror = () => reject('Bild konnte nicht geladen werden');
+                img.src = reader.result.toString();
+            };
+
+            reader.onerror = () => reject('Datei konnte nicht gelesen werden');
+            reader.readAsDataURL(file);
+        });
+    }, [targetWidth, targetHeight]);
+
+    return { processImage };
+}
+
+export default useImageProcessor;

--- a/src/service/apiService.jsx
+++ b/src/service/apiService.jsx
@@ -1,17 +1,17 @@
 const BASE_URL = '/api';
 
 const request = async (method, path, data = null) => {
-    const headers = {
-        'Content-Type': 'application/json',
-    };
-
     const options = {
         method,
-        headers,
         credentials: 'include',
     };
 
-    if (data) {
+    if (data instanceof File) {
+        const formData = new FormData();
+        formData.append('image', data);
+        options.body = formData;
+    } else if (data !== null) {
+        options.headers = { 'Content-Type': 'application/json' };
         options.body = JSON.stringify(data);
     }
 


### PR DESCRIPTION
Ich habe keine komplette Upload Komponente gebaut sondern nur einen imageProcessor, der Bilder auf eine gewünschte Größe zuschneidet und ein JPG File zurück gibt. Außerdem wurde der apiService erweitert  und kann jetzt auch Files hochladen. Verwendet wird dies so:
![image](https://github.com/user-attachments/assets/9b2129a8-ef19-4c67-8eec-8277bc582d9c)

=> result enthält imgId und imgPath vom Server und kann an der jeweiligen Komponente (User&Recommendation) gespeichert werden.

Testen kannst du das gerade schlecht, kommt dann im nächsten Ticket bei den User Daten ändern.